### PR TITLE
Add Grafana support

### DIFF
--- a/demo-steps.md
+++ b/demo-steps.md
@@ -126,7 +126,7 @@ Update the files before moving onto the next steps.
 
 ## Step 3. (Extra) Set Up MetalLB
 
-MetalLB can make it a more realistic cluster setup, and allow you to not need to consider too much about the Docker Network (except for the IP CIDR range mentioned above). 
+MetalLB can make it a more realistic cluster setup, and allow you to not need to consider too much about the Docker Network (except for the IP CIDR range mentioned above).
 
 This step isn't required if you are to work out the network setup using NodePort within Docker Network, and also if you are not using KinD, skip this step.
 
@@ -263,14 +263,14 @@ Istio comes with some default dummy certificate provided, but it is certainly no
     # simpler and cleaner. All the certificates will then be created under the
     # same `certs` directory.
     pushd certs > /dev/null
-    
+
     # Before generating the certificate for each cluster, we need to create a
     # Root CA Certificate, which can be used to sign the actual certificates
     # in the next step.
     # As Istio's script is a Makefile, we are using make command. It means we
     # could pass `-f` flag and use different directory if you wish so.
     make -f ./Makefile.selfsigned.mk root-ca
-    
+
     # Although we would be back to the same directory in the next step, making
     # sure that we get back to the original directory we were in before.
     popd > /dev/null
@@ -291,7 +291,7 @@ Istio comes with some default dummy certificate provided, but it is certainly no
     make -f ./Makefile.selfsigned.mk cluster-1-cacerts;
     make -f ./Makefile.selfsigned.mk cluster-2-cacerts;
     make -f ./Makefile.selfsigned.mk cluster-3-cacerts;
-    
+
     # Once we have all the certificates created, get back to the original
     # directory.
     popd > /dev/null
@@ -474,11 +474,11 @@ In this step, we will look at each step of establishing the connection between c
     # specifically for `Gateway` from kubecon-eu-2023.tar.gz, using `--strip`
     # argument to simplify the directory structure.
 
-    # Istio's cross-network-gateway is a simple `Gateway` CR provided by the 
+    # Istio's cross-network-gateway is a simple `Gateway` CR provided by the
     # Istio official repository (you can use a script to generate this).
     # With this resource, we can configure Istio IngressGateway (and other Data
     # Plane components).
-    # 
+    #
     # The configuration is quite simple:
     #
     # apiVersion: networking.istio.io/v1alpha3
@@ -536,7 +536,7 @@ The official way for creating remote secrets use `istioctl create-remote-secret`
 ```sh
 {
     # This step is for cluster-1 -> cluster-2
-    
+
     CONTEXT=kind-cluster-1
     CLUSTER=cluster-2
 
@@ -547,7 +547,7 @@ The official way for creating remote secrets use `istioctl create-remote-secret`
         --namespace istio-system \
         create secret generic istio-remote-secret-$CLUSTER \
         --from-file=$CLUSTER=${CLUSTER}-kubeconfig.yaml
-        
+
     # Next, we also annotate with the network topology, the same way as
     # istioctl.
     kubectl --context $CONTEXT \
@@ -569,7 +569,7 @@ The rest of the steps are exactly the same as above, just for different cluster 
 ```sh
 {
     # This step is for cluster-2 -> cluster-1
-    
+
     CONTEXT=kind-cluster-2
     CLUSTER=cluster-1
 
@@ -592,7 +592,7 @@ The rest of the steps are exactly the same as above, just for different cluster 
 ```sh
 {
     # This step is for cluster-1 -> cluster-3
-    
+
     CONTEXT=kind-cluster-1
     CLUSTER=cluster-3
 
@@ -616,7 +616,7 @@ The rest of the steps are exactly the same as above, just for different cluster 
 ```sh
 {
     # This step is for cluster-2 -> cluster-3
-    
+
     CONTEXT=kind-cluster-2
     CLUSTER=cluster-3
 
@@ -703,11 +703,11 @@ In order to simulate more realistic use cases, the steps here will make use of m
     # Also, because the Prometheus Operator CRDs are quite lengthy and exceeds
     # the limit for client side apply, we are using `--server-side` flag to have
     # them applied on the server instead.
-    kustomize build prometheus/operator-installation | 
+    kustomize build prometheus/operator-installation |
         kubectl apply --context kind-cluster-1 --server-side -f -
-    kustomize build prometheus/operator-installation | 
+    kustomize build prometheus/operator-installation |
         kubectl apply --context kind-cluster-2 --server-side -f -
-    kustomize build prometheus/operator-installation | 
+    kustomize build prometheus/operator-installation |
         kubectl apply --context kind-cluster-3 --server-side -f -
 }
 ```
@@ -744,11 +744,11 @@ The second Prometheus is "istio-federation", which bundles all Prometheus metric
     #   federation later on, by adding a prefix such as "federate:". we would
     #   see how Prometheus "istio-federation" setup takes advantage of this
     #   setup for better metrics management.
-    kustomize build prometheus/istio-collector | 
+    kustomize build prometheus/istio-collector |
         kubectl apply --context kind-cluster-1 -f -
     kustomize build prometheus/istio-collector |
         kubectl apply --context kind-cluster-2 -f -
-    kustomize build prometheus/istio-collector | 
+    kustomize build prometheus/istio-collector |
         kubectl apply --context kind-cluster-3 -f -
 }
 ```
@@ -766,15 +766,15 @@ The second Prometheus is "istio-federation", which bundles all Prometheus metric
     # Istio Sidecar only for certificate handling. The notable difference is
     # that "istio-federation" has a Remote Write endpoint for data retention.
     # This is a simple approach to merge all the metrics taken into a dedicated
-    # central observability cluster, in our case `cluster-3`. 
+    # central observability cluster, in our case `cluster-3`.
     #
     # Prometheus scraping config for this is quite simple. It finds the metrics
     # with "federate:" prefix, and strips the prefix.
-    kustomize build prometheus/istio-federation-cluster-1 | 
+    kustomize build prometheus/istio-federation-cluster-1 |
         kubectl apply --context kind-cluster-1 -f -
-    kustomize build prometheus/istio-federation-cluster-2 | 
+    kustomize build prometheus/istio-federation-cluster-2 |
         kubectl apply --context kind-cluster-2 -f -
-    kustomize build prometheus/istio-federation-cluster-3 | 
+    kustomize build prometheus/istio-federation-cluster-3 |
         kubectl apply --context kind-cluster-3 -f -
 }
 ```

--- a/demo-steps.md
+++ b/demo-steps.md
@@ -823,6 +823,45 @@ Also, with this approach, Thanos is only needed in the "target" cluster where th
 }
 ```
 
+### Step 9.2. Install Grafana to `cluster-3`
+
+```sh
+{
+    # Similarly to Thanos, we are deploying Grafana into `cluster-3`. It will
+    # use Thanos as the data source. Hence, Grafana will have access to the
+    # telemetry data from all environments.
+    #
+    # Additionally, we set sidecars for dashboards and data sources to watch all
+    # config maps (or secrets) and dynamically import required resources.
+    helm install --repo https://grafana.github.io/helm-charts \
+        --kube-context kind-cluster-3 \
+        --set sidecar.dashboards.enabled=true \
+        --set sidecar.datasources.enabled=true \
+        grafana grafana -n monitoring
+}
+```
+
+### Step 9.3. Pull Out Grafana Related Configurations
+
+```sh
+{
+    # Like Prometheus configurations, we can pull out the relevant Grafana
+    # related configurations around Grafana Data Source and Dashboards from
+    # kubecon-eu-2023.tar.gz, using `--strip` argument to simplify the directory
+    # structure.
+    tar -xz -f kubecon-eu-2023.tar.gz \
+        --strip=2 kubecon-eu-2023-main/manifests/grafana
+}
+```
+
+### Step 9.4. Configure Grafana's Data Source and Create Sample Dashboard
+
+```sh
+{
+    kustomize build grafana |
+        kubectl apply --context kind-cluster-3 -f -
+}
+```
 
 ## Step 10. Play and Explore 🎢
 

--- a/demo.sh
+++ b/demo.sh
@@ -167,3 +167,15 @@ execute 'helm install --repo https://charts.bitnami.com/bitnami \
     --kube-context kind-cluster-3 \
     --set receive.enabled=true \
     thanos thanos -n monitoring'
+comment "6.2. Install Grafana to cluster-3."
+execute 'helm install --repo https://grafana.github.io/helm-charts \
+    --kube-context kind-cluster-3 \
+    --set sidecar.dashboards.enabled=true \
+    --set sidecar.datasources.enabled=true \
+    grafana grafana -n monitoring'
+comment "6.3. Get Grafana configs specific for the demo."
+execute 'tar -xz -f kubecon-eu-2023.tar.gz \
+    --strip=2 kubecon-eu-2023-main/manifests/grafana'
+comment "6.4. Configure Grafana's Data Source and Create Sample Dashboard."
+execute 'kustomize build grafana |
+    kubectl apply --context kind-cluster-3 -f -'

--- a/manifests/grafana/grafana-configs/dashboard.yaml
+++ b/manifests/grafana/grafana-configs/dashboard.yaml
@@ -1,0 +1,1113 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sample-grafana-dashboard
+  labels:
+     grafana_dashboard: "1"
+data:
+  k8s-dashboard.json: |-
+    {
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": "Thanos",
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "type": "dashboard"
+          }
+        ]
+      },
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 0,
+      "id": 9,
+      "links": [],
+      "liveNow": false,
+      "panels": [
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "id": 10,
+          "panels": [],
+          "title": "Control Plane",
+          "type": "row"
+        },
+        {
+          "datasource": "Thanos",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "inspect": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "cluster"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 161
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 1
+          },
+          "id": 13,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": false,
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true,
+            "sortBy": []
+          },
+          "pluginVersion": "9.5.2",
+          "targets": [
+            {
+              "datasource": "Thanos",
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "group by (cluster, version) (pilot_info{cluster=~\"$cluster\"})",
+              "format": "table",
+              "instant": true,
+              "interval": "1",
+              "legendFormat": "__auto",
+              "range": false,
+              "refId": "A"
+            }
+          ],
+          "title": "Istio version",
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true,
+                  "Value": true
+                },
+                "indexByName": {},
+                "renameByName": {}
+              }
+            }
+          ],
+          "type": "table"
+        },
+        {
+          "datasource": "Thanos",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 1
+          },
+          "id": 11,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": "Thanos",
+              "editorMode": "code",
+              "expr": "sum by (cluster, type) (irate(pilot_xds_pushes{cluster=~\"$cluster\"}[1m]))",
+              "legendFormat": "{{cluster}} {{type}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Pilot XDS Pushes",
+          "type": "timeseries"
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Thanos",
+          "fieldConfig": {
+            "defaults": {
+              "links": []
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 0,
+            "y": 9
+          },
+          "hiddenSeries": false,
+          "id": 14,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "9.5.2",
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": "Thanos",
+              "editorMode": "code",
+              "expr": "pilot_virt_services{job=\"pilot\", cluster=~\"$cluster\"}",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "{{cluster}} Virtual Services",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": "Thanos",
+              "editorMode": "code",
+              "expr": "pilot_services{job=\"pilot\", cluster=~\"$cluster\"}",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "{{cluster}} Services",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": "Thanos",
+              "editorMode": "code",
+              "expr": "pilot_xds{job=\"pilot\", cluster=~\"$cluster\"}",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "{{cluster}} Connected Endpoints",
+              "range": true,
+              "refId": "E"
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "ADS Monitoring",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "logBase": 1,
+              "show": true
+            },
+            {
+              "format": "short",
+              "logBase": 1,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
+        },
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 18
+          },
+          "id": 9,
+          "panels": [],
+          "title": "Data Plane",
+          "type": "row"
+        },
+        {
+          "datasource": "Thanos",
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 19
+          },
+          "id": 1,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": "Thanos",
+              "editorMode": "code",
+              "expr": "istio_requests_total:destination:rate1m{cluster=~\"$cluster\", destination_workload_namespace=~\"$namespace\"}",
+              "legendFormat": "{{destination_workload}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Incoming Requests Rate",
+          "type": "timeseries"
+        },
+        {
+          "datasource": "Thanos",
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 19
+          },
+          "id": 2,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": "Thanos",
+              "editorMode": "code",
+              "expr": "istio_requests_total:source:rate1m{cluster=~\"$cluster\", source_workload_namespace=~\"$namespace\"}",
+              "legendFormat": "{{destination_workload}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Outgoing Requests Rate",
+          "type": "timeseries"
+        },
+        {
+          "datasource": "Thanos",
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 27
+          },
+          "id": 3,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": "Thanos",
+              "editorMode": "code",
+              "expr": "sum by (cluster) (istio_requests_total:destination:rate1m{cluster=~\"$cluster\", destination_workload_namespace=~\"$namespace\"})",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Incoming Requests Rate in Cluster",
+          "type": "timeseries"
+        },
+        {
+          "datasource": "Thanos",
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 27
+          },
+          "id": 4,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": "Thanos",
+              "editorMode": "code",
+              "expr": "sum by (cluster) (istio_requests_total:source:rate1m{cluster=~\"$cluster\", source_workload_namespace=~\"$namespace\"})",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Outgoing Requests Rate in Cluster",
+          "type": "timeseries"
+        },
+        {
+          "datasource": "Thanos",
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 35
+          },
+          "id": 5,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": "Thanos",
+              "editorMode": "code",
+              "expr": "istio_tcp_sent_bytes_total:source:rate1m{cluster=~\"$cluster\", destination_workload_namespace=~\"$namespace\"}",
+              "legendFormat": "{{destination_workload}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Istio TCP Sent Bytes at Source",
+          "type": "timeseries"
+        },
+        {
+          "datasource": "Thanos",
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 35
+          },
+          "id": 7,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": "Thanos",
+              "editorMode": "code",
+              "expr": "istio_tcp_received_bytes_total:source:rate1m{cluster=~\"$cluster\", destination_workload_namespace=~\"$namespace\"}",
+              "legendFormat": "{{destination_workload}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Istio TCP Received Bytes at Source",
+          "type": "timeseries"
+        },
+        {
+          "datasource": "Thanos",
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 43
+          },
+          "id": 6,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": "Thanos",
+              "editorMode": "code",
+              "expr": "sum by (cluster) (istio_tcp_sent_bytes_total:source:rate1m{source_workload=\"istio-eastwestgateway\"})",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Istio TCP Sent Bytes by East West Gateway",
+          "type": "timeseries"
+        },
+        {
+          "datasource": "Thanos",
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 43
+          },
+          "id": 8,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": "Thanos",
+              "editorMode": "code",
+              "expr": "sum by (cluster) (istio_tcp_received_bytes_total:source:rate1m{source_workload=\"istio-eastwestgateway\"})",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Istio TCP Received Bytes by East West Gateway",
+          "type": "timeseries"
+        }
+      ],
+      "refresh": "",
+      "schemaVersion": 38,
+      "style": "dark",
+      "tags": [],
+      "templating": {
+        "list": [
+          {
+            "allValue": ".*",
+            "current": {
+              "selected": false,
+              "text": "All",
+              "value": "$__all"
+            },
+            "datasource": {
+              "type": "datasource",
+              "uid": "grafana"
+            },
+            "definition": "label_values(cluster)",
+            "hide": 0,
+            "includeAll": true,
+            "label": "Cluster",
+            "multi": true,
+            "name": "cluster",
+            "options": [],
+            "query": {
+              "query": "label_values(cluster)",
+              "refId": "PrometheusVariableQueryEditor-VariableQuery"
+            },
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 0,
+            "type": "query"
+          },
+          {
+            "allValue": ".*",
+            "current": {
+              "selected": false,
+              "text": "All",
+              "value": "$__all"
+            },
+            "datasource": {
+              "type": "datasource",
+              "uid": "grafana"
+            },
+            "definition": "label_values(destination_workload_namespace)",
+            "hide": 0,
+            "includeAll": true,
+            "label": "Namespace",
+            "multi": true,
+            "name": "namespace",
+            "options": [],
+            "query": {
+              "query": "label_values(destination_workload_namespace)",
+              "refId": "PrometheusVariableQueryEditor-VariableQuery"
+            },
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 0,
+            "type": "query"
+          }
+        ]
+      },
+      "time": {
+        "from": "now-15m",
+        "to": "now"
+      },
+      "timepicker": {},
+      "timezone": "",
+      "title": "Multicluster",
+      "uid": "adce78c1-2938-4590-8a91-1ce835dd6269",
+      "version": 1,
+      "weekStart": ""
+    }

--- a/manifests/grafana/grafana-configs/datasource.yaml
+++ b/manifests/grafana/grafana-configs/datasource.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: grafana-datasources
+  labels:
+    grafana_datasource: 'true' # default value for: sidecar.datasources.label
+stringData:
+  prom.yaml: |-
+    apiVersion: 1
+    datasources:
+    - name: Thanos
+      type: prometheus
+      # Access mode - proxy (server in the UI) or direct (browser in the UI).
+      access: proxy
+      url: http://thanos-query-frontend:9090
+      jsonData:
+        httpMethod: POST
+        manageAlerts: true
+        prometheusType: Thanos
+        cacheLevel: 'High'

--- a/manifests/grafana/grafana-configs/kustomization.yaml
+++ b/manifests/grafana/grafana-configs/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: monitoring
+
+resources:
+  - dashboard.yaml
+  - datasource.yaml

--- a/manifests/grafana/kustomization.yaml
+++ b/manifests/grafana/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: monitoring
+
+resources:
+  - grafana-configs

--- a/manifests/prometheus/istio-collector/prometheus-configs/istio-rules-federation.yaml
+++ b/manifests/prometheus/istio-collector/prometheus-configs/istio-rules-federation.yaml
@@ -124,6 +124,38 @@ spec:
               response_flags
             )
 
+    - name: istio.workload.istio_tcp_sent_bytes_total:source
+      interval: 10s
+      rules:
+        - record: federate:istio_tcp_sent_bytes_total:source:rate1m
+          expr: |
+            sum(irate(istio_tcp_sent_bytes_total{reporter="source", source_workload!=""}[1m]))
+            by (
+              source_workload,
+              source_workload_namespace,
+              destination_service,
+              destination_workload,
+              destination_workload_namespace,
+              response_code,
+              response_flags
+            )
+
+    - name: istio.workload.istio_tcp_received_bytes_total:source
+      interval: 10s
+      rules:
+        - record: federate:istio_tcp_received_bytes_total:source:rate1m
+          expr: |
+            sum(irate(istio_tcp_received_bytes_total{reporter="source", source_workload!=""}[1m]))
+            by (
+              source_workload,
+              source_workload_namespace,
+              destination_service,
+              destination_workload,
+              destination_workload_namespace,
+              response_code,
+              response_flags
+            )
+
     # These rules should be fast, and only operate on the aggregates defined above
     - name: istio.recording-rules-percentiles
       interval: 10s

--- a/manifests/prometheus/istio-federation-cluster-1/prometheus-configs/istio-federation-monitor.yaml
+++ b/manifests/prometheus/istio-federation-cluster-1/prometheus-configs/istio-federation-monitor.yaml
@@ -23,7 +23,7 @@ spec:
           #   https://karlstoney.com/2020/02/25/federated-prometheus-to-reduce-metric-cardinality/
           - '{__name__=~"federate:(.*)"}'
           # - '{__name__=~"workload:(.*)"}'
-          # - '{__name__=~"pilot(.*)"}'
+          - '{__name__=~"pilot(.*)"}'
       path: /federate
       targetPort: 9090
       honorLabels: true

--- a/manifests/prometheus/istio-federation-cluster-2/prometheus-configs/istio-federation-monitor.yaml
+++ b/manifests/prometheus/istio-federation-cluster-2/prometheus-configs/istio-federation-monitor.yaml
@@ -23,7 +23,7 @@ spec:
           #   https://karlstoney.com/2020/02/25/federated-prometheus-to-reduce-metric-cardinality/
           - '{__name__=~"federate:(.*)"}'
           # - '{__name__=~"workload:(.*)"}'
-          # - '{__name__=~"pilot(.*)"}'
+          - '{__name__=~"pilot(.*)"}'
       path: /federate
       targetPort: 9090
       honorLabels: true

--- a/manifests/prometheus/istio-federation-cluster-3/prometheus-configs/istio-federation-monitor.yaml
+++ b/manifests/prometheus/istio-federation-cluster-3/prometheus-configs/istio-federation-monitor.yaml
@@ -23,7 +23,7 @@ spec:
           #   https://karlstoney.com/2020/02/25/federated-prometheus-to-reduce-metric-cardinality/
           - '{__name__=~"federate:(.*)"}'
           # - '{__name__=~"workload:(.*)"}'
-          # - '{__name__=~"pilot(.*)"}'
+          - '{__name__=~"pilot(.*)"}'
       path: /federate
       targetPort: 9090
       honorLabels: true


### PR DESCRIPTION
This PR introduces several changes:
- enable Istio Control Plane (`pilot.*`) metrics,
- add Grafana deployment to `kind-cluster-3` using Helm chart,
- configure Thanos Query Frontend data source,
- add sample multicluster Grafana dashboard.